### PR TITLE
Move branch assignment into queryForPages call, which shouldn't run

### DIFF
--- a/page/script/page.js
+++ b/page/script/page.js
@@ -17,7 +17,6 @@ define(function(require, exports, module) {
   var validUrlSelector = "." + validUrlClass
   var duplicateUrlClass = "duplicate-url-message"
   var duplicateUrlSelector = "." + duplicateUrlClass
-  var branch = Ratchet.observable('branch').get()
   var latestPagesRequestTime
   var timer = undefined
   var docId = null
@@ -58,6 +57,7 @@ define(function(require, exports, module) {
   }
 
   function queryForPages(url) {
+    var branch = Ratchet.observable('branch').get()
     var chain = Chain(branch).trap(genericErrorLoggerHalter)
     return chain.queryNodes({
       _type: {


### PR DESCRIPTION
until page content is ready (and theoretically Ratchet/Chain and their
dependencies have loaded)