### PR TITLE
clone save button off so we show only an un-wired, disabled clone

### DIFF
--- a/page/script/page.js
+++ b/page/script/page.js
@@ -97,8 +97,7 @@ define(function(require, exports, module) {
         $elemMatch: {
           url: url
         }
-      },
-      active: 'y'
+      }
     })
   }
 
@@ -150,11 +149,14 @@ define(function(require, exports, module) {
   $(document).on('cloudcms-ready', function(event) {
     $(urlTextSelector).off()
     //detect if current page is edit properties
-    var pagePattern = /^.*\/documents\/(\w+)\/properties$/
-    var isPage = pagePattern.test(location.href)
-    if (isPage) {
-      docId = location.href.replace(pagePattern, '$1')
+    var editPropertiesPattern = /^.*\/documents\/(\w+)\/properties$/
+    var isEditProperties = editPropertiesPattern.test(location.href)
+    if (isEditProperties) {
+      docId = location.href.replace(editPropertiesPattern, '$1')
       findIdenticalUrlPages()
+    } else {
+      //if not on edit properties, clear docId
+      docId = null
     }
 
     $(document).on('keyup keydown paste cut change', urlTextSelector, findIdenticalUrlPages)

--- a/page/script/page.js
+++ b/page/script/page.js
@@ -106,7 +106,7 @@ define(function(require, exports, module) {
     if (!isValid && event && event.key && "Enter" === event.key) {
       event.stopPropagation()
       event.preventDefault()
-    } else if (event && "keyup" === event.type) {
+    } else {
       latestPagesRequestTime = new Date().getTime()
       var pagesRequestTime = new Date().getTime()
       var url


### PR DESCRIPTION
while user is typing, and swap back the original (wired) save button once user is done and URL value has been validated as unique against the contents of the CMS' other pages. Also prevent Enter key submission of form if URL !isValid