### PR TITLE
custom-pages/gadgets/reports/reports.js: [NOID]Create button the makes report of missing meta keys available f…

### DIFF
--- a/custom-pages/gadgets/reports/reports.js
+++ b/custom-pages/gadgets/reports/reports.js
@@ -16,13 +16,14 @@ define(function (require, exports, module) {
     const $ = require('jquery')
     const OneTeam = require('oneteam')
 
-    const [PAGE, PRODUCT, SKU, PRICESHEET] = [
+    const [PAGE, PRODUCT, SKU, PRICESHEET, MISSINGMETAKEYS] = [
         'page',
         'product',
         'sku',
-        'price-sheet'
+        'price-sheet',
+        'missing-meta-keys'
     ]
-    const ReportTypes = [PAGE, PRODUCT, SKU, PRICESHEET]
+    const ReportTypes = [PAGE, PRODUCT, SKU, PRICESHEET, MISSINGMETAKEYS]
 
     const QueryTypes = {
         [PAGE]: {
@@ -30,7 +31,10 @@ define(function (require, exports, module) {
         },
         [PRODUCT]: "cricket:product",
         [SKU]: "cricket:sku",
-        [PRICESHEET]: "cricket:price-list"
+        [PRICESHEET]: "cricket:price-list",
+        [MISSINGMETAKEYS]: {
+            "$regex": "cricket:page(-.+)?"
+        }
     }
 
     let branch;
@@ -39,7 +43,50 @@ define(function (require, exports, module) {
     function buildQuery(reportType) {
         let query = { }
         if (reportType in QueryTypes) {
-            query._type = QueryTypes[reportType]
+            query._type = QueryTypes[reportType];
+            if (reportType === MISSINGMETAKEYS){
+                query.metadata={
+                    $not: {
+                      $all: [
+                        {
+                          $elemMatch: {
+                            type: "title"
+                          }
+                        },
+                        {
+                          $elemMatch: {
+                            type: "description"
+                          }
+                        },
+                        {
+                          $elemMatch: {
+                            type: "canonical"
+                          }
+                        },
+                        {
+                          $elemMatch: {
+                            type: "og:title"
+                          }
+                        },
+                        {
+                          $elemMatch: {
+                            type: "og:description"
+                          }
+                        },
+                        {
+                          $elemMatch: {
+                            type: "og:url"
+                          }
+                        },
+                        {
+                          $elemMatch: {
+                            type: "og:image"
+                          }
+                        }
+                      ]
+                    }
+                }
+            }
         } else {
             console.error('Invalid report type provided')
         }
@@ -301,7 +348,7 @@ define(function (require, exports, module) {
          */
         afterSwap: function (el, model, originalContext, callback) {
             this.base(el, model, originalContext, function () {
-                
+           
             });
         }
         

--- a/custom-pages/gadgets/reports/templates/reports.html
+++ b/custom-pages/gadgets/reports/templates/reports.html
@@ -4,4 +4,5 @@
     <button class="btn btn-primary sku">Skus Report</button>
     <button class="btn btn-primary price-sheet">Price Sheets Report</button>
     <button class="btn btn-primary holistic">Holistic Report</button>
+    <button class="btn btn-primary missing-meta-keys">Missing Meta Keys Report</button>
 </div>


### PR DESCRIPTION
# What 
1. Create button in https://cms.cricketwireless.com/#/projects/84078a714594223efebd/reports
2. OnClick of "Missing Meta Keys Report, it should download an excel report returning all pages of `_type` matching the following regex: `cricket:page(-.+)?`

# Pix
_Resulting Report_
<img width="1024" alt="Screen Shot 2019-12-09 at 11 20 51 AM" src="https://user-images.githubusercontent.com/13541552/70452982-ff016a00-1a75-11ea-8ebc-c69a35d9fe70.png">

Closes: [NOID]
Pull: #23
Reviewers: @thynctank, @tenoriojuann 